### PR TITLE
Byte pattern matching for Smash > 9.0.2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use parking_lot::Mutex;
 use image::DynamicImage;
 
-use skyline::hooks::InlineCtx;
+use skyline::hooks::{
+    getRegionAddress,
+    Region,
+    InlineCtx
+};
 use smash::lib::lua_const::FIGHTER_KIND_PICKEL;
 
 mod keyboard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,11 @@ extern "C" fn chara_6_callback(hash: u64, data: *mut u8, size: usize) -> bool {
     }
 }
 
-pub fn search_offsets() {
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|window| window == needle)
+}
+
+fn search_offsets() {
     unsafe {
         let text_ptr = getRegionAddress(Region::Text) as *const u8;
         let text_size = (getRegionAddress(Region::Rodata) as usize) - (text_ptr as usize);


### PR DESCRIPTION
This should make the plugin compatible for future updates. Untested. (Missing render dependency)