### PR TITLE
Change color correction numbers

### DIFF
--- a/src/color_correct.rs
+++ b/src/color_correct.rs
@@ -9,7 +9,7 @@ pub fn color_correct(skin_data: &mut image::RgbaImage) {
                 let pixel = &mut channels[i];
                 
                 // gamma brightening by a factor of 1.385, bounded to [0, 184]
-                *pixel = ((((*pixel as f64) / 255.0).powf(1.0f64 / 1.385f64) * 255.0) * 184.0 / 255.0) as u8;
+                *pixel = ((((*pixel as f64) / 255.0).powf(1.0f64 / 1.200f64) * 255.0) * 191.0 / 255.0) as u8;
             }
         }
     }


### PR DESCRIPTION
Steve from Smash and Minecraft do not have the same skin tone, so the numbers gathered for color correction are slightly off. I compared their leg colors (since they should be exactly the same) and got these numbers instead. A factor of 1.200, and bounded to 191.