### PR TITLE
use git dependency for minecraft_render

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ percent-encoding = "=2.1.0"
 color-thief = "0.2.1"
 ordered-float = "2.0.0"
 
-minecraft_render = { path = "../smash_minecraft_renders", optional = true }
+minecraft_render = { git = "https://github.com/ScanMountGoat/smash_minecraft_renders", rev = "1cbdd2b", optional = true }
 
 [patch.crates-io]
 ring = { git = "https://github.com/skyline-rs/ring" }


### PR DESCRIPTION
I have no idea if this works. The code hasn't changed at all, so I'm going to assume it at least isn't more broken than before.